### PR TITLE
Patch bug when filtering badges list page

### DIFF
--- a/templates/core/badges/list.html
+++ b/templates/core/badges/list.html
@@ -13,7 +13,7 @@
 
 <div class="row mb-4">
     <div class="col-md-6">
-        <form class="d-flex" hx-get="{% url 'core:badge-list' %}" hx-target="#badge-list" hx-swap="outerHTML">
+        <form class="d-flex" hx-get="{% url 'core:badge-list' %}" hx-target="#badge-list" hx-swap="innerHTML">
             <input class="form-control me-2" type="search" placeholder="Rechercher un badge" aria-label="Rechercher" name="search">
             <button class="btn btn-outline-primary" type="submit">Rechercher</button>
         </form>
@@ -31,7 +31,7 @@
         <div class="card">
             <div class="card-body">
                 <h5 class="card-title">Filtres</h5>
-                <form hx-get="{% url 'core:badge-list' %}" hx-target="#badge-list" hx-swap="outerHTML">
+                <form hx-get="{% url 'core:badge-list' %}" hx-target="#badge-list" hx-swap="innerHTML">
                     <div class="mb-3">
                         <label class="form-label fw-bold">Niveau</label>
                         <div class="form-check">

--- a/templates/core/badges/partials/badge_list.html
+++ b/templates/core/badges/partials/badge_list.html
@@ -1,72 +1,70 @@
 {% load pictures %}
 
-<div class="col-md-9" id="badge-list">
-    <div class="badge-grid">
-        {% if badges %}
-            {% for badge in badges %}
-            <div class="card text-center">
-                <div class="card-body">
-                    {% if badge.icon %}
-                    <div class="badge-icon-container">
-                        {% picture badge.icon img_alt="{{ badge.name }}" img_class="badge-icon" ratio="1/1" %}
-                    </div>
-                    {% else %}
-                    <img src="https://via.placeholder.com/100" alt="{{ badge.name }}" class="badge-icon">
-                    {% endif %}
-                    <h5 class="card-title">{{ badge.name }}</h5>
-                    <p class="card-text">
-                        {% if badge.level == 'beginner' %}
-                        <span class="badge bg-primary">{{ badge.get_level_display }}</span>
-                        {% elif badge.level == 'intermediate' %}
-                        <span class="badge bg-warning text-dark">{{ badge.get_level_display }}</span>
-                        {% elif badge.level == 'expert' %}
-                        <span class="badge bg-success">{{ badge.get_level_display }}</span>
-                        {% endif %}
-                    </p>
-                    <p class="card-text text-muted">{{ badge.issuing_structure.name }}</p>
-                    <a href="{% url 'core:badge-detail' pk=badge.id %}" class="btn btn-primary">Voir le badge</a>
+<div class="badge-grid">
+    {% if badges %}
+        {% for badge in badges %}
+        <div class="card text-center">
+            <div class="card-body">
+                {% if badge.icon %}
+                <div class="badge-icon-container">
+                    {% picture badge.icon img_alt="{{ badge.name }}" img_class="badge-icon" ratio="1/1" %}
                 </div>
-            </div>
-            {% endfor %}
-        {% else %}
-            <div class="alert alert-info">
-                Aucun badge ne correspond à vos critères de recherche.
-            </div>
-        {% endif %}
-    </div>
-
-    <!-- Pagination -->
-    {% if is_paginated %}
-    <nav aria-label="Page navigation" class="mt-4">
-        <ul class="pagination justify-content-center">
-            {% if page_obj.has_previous %}
-            <li class="page-item">
-                <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if structure_filter %}&structure={{ structure_filter }}{% endif %}" tabindex="-1">Précédent</a>
-            </li>
-            {% else %}
-            <li class="page-item disabled">
-                <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Précédent</a>
-            </li>
-            {% endif %}
-
-            {% for i in paginator.page_range %}
-                {% if page_obj.number == i %}
-                <li class="page-item active"><a class="page-link" href="#">{{ i }}</a></li>
                 {% else %}
-                <li class="page-item"><a class="page-link" href="?page={{ i }}{% if search_query %}&search={{ search_query }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if structure_filter %}&structure={{ structure_filter }}{% endif %}">{{ i }}</a></li>
+                <img src="https://via.placeholder.com/100" alt="{{ badge.name }}" class="badge-icon">
                 {% endif %}
-            {% endfor %}
-
-            {% if page_obj.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if structure_filter %}&structure={{ structure_filter }}{% endif %}">Suivant</a>
-            </li>
-            {% else %}
-            <li class="page-item disabled">
-                <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Suivant</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+                <h5 class="card-title">{{ badge.name }}</h5>
+                <p class="card-text">
+                    {% if badge.level == 'beginner' %}
+                    <span class="badge bg-primary">{{ badge.get_level_display }}</span>
+                    {% elif badge.level == 'intermediate' %}
+                    <span class="badge bg-warning text-dark">{{ badge.get_level_display }}</span>
+                    {% elif badge.level == 'expert' %}
+                    <span class="badge bg-success">{{ badge.get_level_display }}</span>
+                    {% endif %}
+                </p>
+                <p class="card-text text-muted">{{ badge.issuing_structure.name }}</p>
+                <a href="{% url 'core:badge-detail' pk=badge.id %}" class="btn btn-primary">Voir le badge</a>
+            </div>
+        </div>
+        {% endfor %}
+    {% else %}
+        <div class="alert alert-info">
+            Aucun badge ne correspond à vos critères de recherche.
+        </div>
     {% endif %}
 </div>
+
+<!-- Pagination -->
+{% if is_paginated %}
+<nav aria-label="Page navigation" class="mt-4">
+    <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if structure_filter %}&structure={{ structure_filter }}{% endif %}" tabindex="-1">Précédent</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Précédent</a>
+        </li>
+        {% endif %}
+
+        {% for i in paginator.page_range %}
+            {% if page_obj.number == i %}
+            <li class="page-item active"><a class="page-link" href="#">{{ i }}</a></li>
+            {% else %}
+            <li class="page-item"><a class="page-link" href="?page={{ i }}{% if search_query %}&search={{ search_query }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if structure_filter %}&structure={{ structure_filter }}{% endif %}">{{ i }}</a></li>
+            {% endif %}
+        {% endfor %}
+
+        {% if page_obj.has_next %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{ page_obj.next_page_number }}{% if search_query %}&search={{ search_query }}{% endif %}{% if level_filter %}&level={{ level_filter }}{% endif %}{% if structure_filter %}&structure={{ structure_filter }}{% endif %}">Suivant</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled">
+            <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Suivant</a>
+        </li>
+        {% endif %}
+    </ul>
+</nav>
+{% endif %}


### PR DESCRIPTION
Correction de l'issue #11. Il manquait la div avec l'id "badge-list" au template, ce qui faisait que quand les formulaires htmx de [templates/core/badges/list.html](https://github.com/NothRen/FossBadge/blob/main/templates/core/badges/list.html#L16) remplaçaient l'html, il n'y avait plus de div avec le bon id.