### PR TITLE
Fix a bug where badges holders don't appear on badge pages

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -85,10 +85,12 @@ class BadgeViewSet(viewsets.ViewSet):
         Display a specific badge.
         """
         badge = get_object_or_404(Badge, pk=pk)
+        holders = badge.get_holders()
 
         return render(request, 'core/badges/detail.html', {
             'title': f'FossBadge - Badge {badge.name}',
-            'badge': badge
+            'badge': badge,
+            'holders': holders
         })
 
     @action(detail=False, methods=['get', 'post'])

--- a/templates/core/badges/detail.html
+++ b/templates/core/badges/detail.html
@@ -108,9 +108,9 @@
             <div class="card">
                 <div class="card-body">
                     <h3 class="card-title">Ce badge est rattaché à d'autres personnes</h3>
-                    {% if badge.holders.all %}
+                    {% if holders %}
                         <ul class="list-group list-group-flush">
-                            {% for user in badge.holders.all %}
+                            {% for user in holders %}
                                 <li class="list-group-item">{{ user.get_full_name|default:user.username }}</li>
                             {% endfor %}
                         </ul>


### PR DESCRIPTION
Dans tout les cas, la page de détail d'un badge affichait que personne n'y était relié : 
<img width="1681" height="890" alt="image" src="https://github.com/user-attachments/assets/1b94a68f-f910-477d-8e74-79aeeb7ed7c4" />

Après la correction : 
<img width="1360" height="593" alt="image" src="https://github.com/user-attachments/assets/f0346526-6948-46a1-974d-306573418cc0" />
